### PR TITLE
Enhanced License Check

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,12 +10,20 @@
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
 
-name: Eclipse Required License Check
+name: License Check
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 5 * * *"
+  issue_comment:
+    types: [created]
 
 jobs:
   build:
+    if: >
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request && contains(github.event.comment.body, '/check-license'))
     name: Build on JDK ${{ matrix.java_version }} with ${{matrix.test_profiles}} profile
     runs-on: ubuntu-latest
     env:
@@ -24,25 +32,39 @@ jobs:
     strategy:
       matrix:
         java_version: [ 21 ]
-        verify_profiles: [ '-Plicense_check,staging' ]
-    continue-on-error: false
+        verify_profiles: [ '-Plicense_check' ]
 
     steps:
+    steps:
+    - name: Get PR ref
+      if: github.event_name == 'issue_comment'
+      id: pr
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          core.setOutput('ref', pr.data.head.sha);
     - name: Checkout for build
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ steps.pr.outputs.ref || github.ref }}
     - name: Set up JDK
       uses: actions/setup-java@v4.1.0
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ matrix.java_version }}
     - name: configure JDK
       run: |
         secLoc=`find $JAVA_HOME -name java.security`
         sed -i 's/jdk.tls.disabledAlgorithms/# jdk.tls.disabledAlgorithms/g' -i $secLoc
     - name: Build
-      run: mvn -V -U -B ${{matrix.verify_profiles}} org.eclipse.dash:license-tool-plugin:license-check -DexcludeArtifactIds=bsh,jmh-core,jmh-generator-annprocess,swing-layout -pl '!:version-agnostic'
+      run: mvn -ntp -V -U -B ${{matrix.verify_profiles}} org.eclipse.dash:license-tool-plugin:license-check -DexcludeArtifactIds=bsh,jmh-core,jmh-generator-annprocess,swing-layout -pl '!:version-agnostic'
+      continue-on-error: true
     - name: Upload license-check info
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
- As we are getting blacklisted from data websites, we have to limit the usage
- Now the check can be executed manually using /check-license comment
- It will be still manually executed daily on main branch
- It can be executed also from the Actions menu
- Removed staging profile
- Switched to Temurin JDK